### PR TITLE
docs(mise): document github backend and the exe tool option

### DIFF
--- a/skills/mise/References/Tools.md
+++ b/skills/mise/References/Tools.md
@@ -62,7 +62,7 @@ mise installs from many ecosystems. Reference a backend with `backend:name`.
 |---------|--------|---------|
 | Core (built-in) | *(none)* | `node`, `python`, `go`, `ruby`, `java` |
 | aqua | `aqua:` | `aqua:BurntSushi/ripgrep` |
-| GitHub releases (ubi) | `ubi:` | `ubi:cli/cli` |
+| GitHub releases | `github:` | `github:cli/cli` (`ubi:` is the deprecated spelling, removed in mise 2027.1.0) |
 | npm | `npm:` | `npm:prettier` |
 | PyPI (pipx) | `pipx:` | `pipx:black` |
 | Cargo | `cargo:` | `cargo:cargo-edit` |
@@ -74,18 +74,37 @@ Usage is identical across backends:
 
 ```sh
 mise use npm:prettier@latest
-mise use ubi:BurntSushi/ripgrep
+mise use github:BurntSushi/ripgrep
 ```
 
 ```toml
 [tools]
 node = '24'
 "npm:prettier" = 'latest'
-"ubi:BurntSushi/ripgrep" = 'latest'
+"github:BurntSushi/ripgrep" = 'latest'
 "pipx:black" = 'latest'
 ```
 
 `mise registry` shows the tool → backend mapping (e.g. what `ripgrep` resolves to by default).
+
+### GitHub-release gotcha: the binary name is not the repo name
+
+The `github:`/`ubi:` backend looks for an executable matching the **repo** name inside the release
+archive. When they differ the install fails at the extract step with `could not find any files
+matching [<repo>*] in the downloaded archive file` — download and asset-matching both succeeded, so
+the debug log reads healthy right up to that line. Fix it with the `exe` tool option, not a
+different version:
+
+```sh
+mise use -g "github:microsoft/go-sqlcmd[exe=sqlcmd]@1.10.0"   # archive ships sqlcmd, repo is go-sqlcmd
+```
+
+```toml
+"github:microsoft/go-sqlcmd" = { version = "1.10.0", exe = "sqlcmd" }
+```
+
+Under `MISE_VERBOSE=1` the lines that name the real contents are `found tarball entry with path
+'<name>'` — read those to pick the right `exe` value.
 
 ## One-off under a specific version
 
@@ -99,6 +118,6 @@ mise x node@22 -- npm ci
 - A **language/runtime** (node, python, go, ruby, java) → core backend, bare name.
 - A **CLI tool** that has a core/aqua entry → prefer `aqua:` or the bare registry name (signed,
   cross-platform, no compile).
-- A **GitHub-release binary** with no registry entry → `ubi:owner/repo`.
+- A **GitHub-release binary** with no registry entry → `github:owner/repo`.
 - An **ecosystem package** (a formatter, linter) → the matching `npm:` / `pipx:` / `cargo:` backend so
   the version is pinned alongside everything else instead of installed globally out-of-band.


### PR DESCRIPTION
## Summary

Documents the `github:` backend in the mise skill's tool reference and adds the failure mode that sent me here: a GitHub-release install that fails at extraction because the archive's binary name differs from the repo name.

## Changes

- Backend table now lists `github:` as the GitHub-releases backend, noting `ubi:` as the deprecated spelling (removed in mise 2027.1.0). Examples in the `mise use` / `[tools]` snippets and the "which backend" bullet updated to match.
- New section **"GitHub-release gotcha: the binary name is not the repo name"** — the backend looks for an executable matching the *repo* name, so `microsoft/go-sqlcmd` (archive ships `sqlcmd`) fails with `could not find any files matching [go-sqlcmd*] in the downloaded archive file`. Download and asset-matching both succeed first, so the debug log reads healthy right up to that line. Fix is the `exe` tool option, in both CLI and `mise.toml` form.

## Verification

Reproduced and fixed against a real install:

```
$ mise use -g "github:microsoft/go-sqlcmd[exe=sqlcmd]@1.10.0"
$ mise which sqlcmd
/home/…/.local/share/mise/installs/github-microsoft-go-sqlcmd/1.10.0/sqlcmd
$ sqlcmd --version
Version: v1.10.0
```

Config round-trips as `"github:microsoft/go-sqlcmd" = { version = "1.10.0", exe = "sqlcmd" }`. Repo pre-commit `Validate skills against agent-skills-spec` passed. Docs-only change; no skill logic touched.

## Summary by Sourcery

Update the mise tool reference with current GitHub backend usage and guidance for configuring release executables with non-matching names.

Enhancements:
- Update mise tool documentation to use the `github:` backend and identify `ubi:` as deprecated.
- Document how to use the `exe` option when a GitHub release archive's executable name differs from its repository name.

Documentation:
- Add GitHub-release backend guidance, examples, and troubleshooting for binary-name mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub release configuration examples to use the current `github:` syntax.
  * Documented that the deprecated `ubi:` syntax will be removed in mise 2027.1.0.
  * Added guidance for releases where the executable name differs from the repository name, including `exe` configuration and TOML examples.
  * Added verbose-log troubleshooting guidance and clarified backend selection recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->